### PR TITLE
verify existence of cookies when defining sid

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -96,7 +96,7 @@ Strategy.prototype.authenticate = function (req, options) {
 	var self = this;
 
 	// old or new SID cookie
-	var sid = req.cookies['dashboard.sid'] || req.cookies['connect.sid'];
+	var sid = (req.cookies) ? req.cookies['dashboard.sid'] || req.cookies['connect.sid'] : false;
 
 	// taken from passport-oauth1
 	var callbackURL = options.callbackURL || this._callbackURL;


### PR DESCRIPTION
Avoiding `undefined` if cookies are not available
